### PR TITLE
fix(glob): made glob setting work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "mocha": "^4.0.1",
         "tslint": "^5.8.0",
         "typescript": "^2.5.3",
-        "vscode": "^1.1.6"
+        "vscode": "^1.1.10"
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/src/NodeTDD.ts
+++ b/src/NodeTDD.ts
@@ -33,7 +33,7 @@ export class NodeTDD {
     }
 
     private constructor() {
-        if (workspace.rootPath) {
+        if (workspace.workspaceFolders) {
             this.outputChannel = window.createOutputChannel(config.OUTPUT_CHANNEL_NAME);
             this.testRunner = new TestRunner();
 

--- a/src/TestRunner.ts
+++ b/src/TestRunner.ts
@@ -1,6 +1,5 @@
 import { spawn, ChildProcess } from 'child_process';
-import { resolve } from 'path';
-import { window, workspace, FileSystemWatcher } from 'vscode';
+import { window, workspace, FileSystemWatcher, RelativePattern } from 'vscode';
 const debounce = require('lodash.debounce');
 const kill = require('tree-kill');
 
@@ -17,7 +16,10 @@ export class TestRunner {
         const buildOnDelete = NodeTDD.getConfig<boolean>(config.BUILD_ON_DELETE);
 
         if (!this.fsWatcher) {
-            const globPath = resolve(workspace.rootPath, NodeTDD.getConfig<string>(config.GLOB));
+            // It's safe to assume workspace.workspaceFolders to exist,
+            // because it has been checked already before calling watch()
+            const globPath = new RelativePattern(
+                workspace.workspaceFolders![0], NodeTDD.getConfig<string>(config.GLOB));
 
             this.fsWatcher = workspace.createFileSystemWatcher(
                 globPath, !buildOnCreate, false, !buildOnDelete);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,9 +1736,9 @@ vinyl@~2.0.1:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vscode@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.6.tgz#46ed1afa2c1b9d689f6394c8f16bd1d7190f75fb"
+vscode@1.1.10:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.10.tgz#d1cba378ab24f1d3ddf9cd470d242ee1472dd35b"
   dependencies:
     glob "^7.1.2"
     gulp-chmod "^2.0.0"


### PR DESCRIPTION
- Updated vscode version
- Use RelativePattern instead of path.resolve()
- Change deprecated rootPath call to workspaceFolders

Fixes #19