### PR TITLE
Add flexibility to run any command (with current file path placeholders)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,16 +8,10 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
 
     // we want to run npm
     "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
 
     // we run the custom script "compile" as defined in package.json
     "args": ["run", "compile", "--loglevel", "silent"],
@@ -26,5 +20,24 @@
     "isWatching": true,
 
     // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "problemMatcher": "$tsc-watch",
+    "tasks": [
+        {
+            "label": "npm",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "compile",
+                "--loglevel",
+                "silent"
+            ],
+            "isBackground": true,
+            "problemMatcher": "$tsc-watch",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
+        }
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
                     "default": true
                 },
                 "nodeTdd.testCommandArray": {
-                    "description": "Command line items to be passed to spawn(). Placeholders available:\n\n$FILE_PATH_LOCAL - the path to the current open file relative to workspace 1\n$FILE_PATH_FULL - the full absolute path to the current open file",
+                    "description": "Command line items to be passed to spawn(). Placeholders available:\n$FILE_PATH_LOCAL - the path to the current open file relative to workspace 1\n$FILE_PATH_FULL - the full absolute path to the current open file\n",
                     "type": "array",
                     "items": {
                         "description": "Arg value",

--- a/package.json
+++ b/package.json
@@ -29,17 +29,17 @@
     ],
     "dependencies": {
         "lodash.debounce": "^4.0.8",
-        "tap-parser": "^6.0.1",
-        "tree-kill": "^1.2.0",
-        "tslib": "^1.8.0"
+        "tap-parser": "^10.1.0",
+        "tree-kill": "^1.2.2",
+        "tslib": "^2.3.1"
     },
     "devDependencies": {
-        "@types/mocha": "^2.2.43",
-        "@types/node": "^8.0.46",
-        "mocha": "^4.0.1",
-        "tslint": "^5.8.0",
-        "typescript": "^2.5.3",
-        "vscode": "^1.1.6"
+        "@types/mocha": "^9.0.0",
+        "@types/node": "^12.12.6",
+        "mocha": "^9.1.1",
+        "tslint": "^6.1.3",
+        "typescript": "^4.4.2",
+        "vscode": "^1.1.37"
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
@@ -78,10 +78,15 @@
                     "type": "boolean",
                     "default": true
                 },
-                "nodeTdd.testScript": {
-                    "description": "The npm script to run tests",
-                    "type": "string",
-                    "default": "test"
+                "nodeTdd.testCommandArray": {
+                    "description": "Command line items to be passed to spawn(). Placeholders available:\n\n$FILE_PATH_LOCAL - the path to the current open file relative to workspace 1\n$FILE_PATH_FULL - the full absolute path to the current open file",
+                    "type": "array",
+                    "items": {
+                        "description": "Arg value",
+                        "type": "string",
+                        "default": ""
+                    },
+                    "default": ["npm", "test"]
                 },
                 "nodeTdd.glob": {
                     "description": "The glob pattern for files to watch, relative to the workspace root",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const config = {
     PASSING_COLOUR: '#55e269',
 
     ACTIVATE_ON_STARTUP: { name: 'activateOnStartup', defaultValue: true },
-    TEST_SCRIPT: { name: 'testScript', defaultValue: 'test' },
+    TEST_COMMAND_ARRAY: { name: 'testCommandArray', defaultValue: ['npm', 'test'] },
     GLOB: { name: 'glob', defaultValue: '{test,src}/**/*.{js,ts,jsx,tsx}' },
     REPORTER: { name: 'reporter', defaultValue: null },
     VERBOSE: { name: 'verbose', defaultValue: false },


### PR DESCRIPTION
In order to have more flexibility and control over the command that is run, I have made the following changes:
- Instead of hardcoding `npm` command as first `spawn()` arg, I have made it so that any command can be used. This allows one to use any custom command - like docker commands or anything else that does not begin with `npm`. The default command is still `npm test`. _Along with this comes the security implication that any malicious command could do serious damage._
- Includes command placeholders for current file path so that you can just target the current file you are editing.

Due to the nature of `spawn()`, I have replaced the current "testScript" config textfield with an array of strings named "testCommandArray". Array item 0 is used as the first `spawn()` arg, and the rest are passed into `spawn()` arg 2.

Here is an example with placeholders. The following configuration is an array of 4 strings:
1. npm
2. run
3. testDebug
4. $FILE_PATH_LOCAL
<img width="529" alt="Screen Shot 2021-09-05 at 7 19 14 PM" src="https://user-images.githubusercontent.com/135516/132151450-bd8183ce-7bb3-4113-b031-77aafaceb5fa.png">

Which has this JSON representation:
```
"nodeTdd.testCommandArray": [
  "npm",
  "run",
  "testDebug",
  "$FILE_PATH_LOCAL"
]
```
The command that is run looks like: `npm run testDebug test/something.test.js`. If your test runner requires other command line args like a `--` before the file path arg, you have the flexibility to add that. I tried using docker & docker-compose exec/run commands using this approach and it works as long as you do not allocate a TTY (see `-t` and `-T` flags).

Just a note about the changes:
- `.vscode/tasks.json` - these were made automatically by VSCode.
- `package.json` - I updated the deps to latest versions. These changes are probably not required, and may affect older Node version (8?) compatibility. I updated `@types/node` to 12.

Addresses https://github.com/prashaantt/node-tdd/issues/27 and https://github.com/prashaantt/node-tdd/issues/24.